### PR TITLE
Add Wasm support for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build
+        run: make build
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./web

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+web/*.wasm
+web/wasm_exec.js

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+build:
+	cp $$(go env GOROOT)/lib/wasm/wasm_exec.js web/
+	GOOS=js GOARCH=wasm go build -o web/main.wasm web/main.go

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Gus.io Wasm</title>
+</head>
+<body>
+    <script src="wasm_exec.js"></script>
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("main.wasm"), go.importObject).then((result) => {
+            go.run(result.instance);
+        });
+    </script>
+    <pre id="json-output">Loading...</pre>
+</body>
+</html>

--- a/web/main.go
+++ b/web/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"syscall/js"
+	"time"
+)
+
+type IpifyResponse struct {
+	Ip string `json:"ip"`
+}
+
+func main() {
+	c := make(chan struct{}, 0)
+
+	go func() {
+		output := js.Global().Get("document").Call("getElementById", "json-output")
+		if output.IsNull() {
+			fmt.Println("Element with id 'json-output' not found")
+			return
+		}
+
+		ip := "Unknown (fetch failed)"
+		resp, err := http.Get("https://api.ipify.org?format=json")
+		if err == nil {
+			defer resp.Body.Close()
+			body, err := io.ReadAll(resp.Body)
+			if err == nil {
+				var ipify IpifyResponse
+				if err := json.Unmarshal(body, &ipify); err == nil {
+					ip = ipify.Ip
+				}
+			}
+		}
+
+		now := time.Now().UTC().Format("2006-01-02 15:04:05")
+
+		result := map[string]interface{}{
+			"api.gus.io": map[string]string{
+				"now_utc":    now,
+				"Your_IP":    ip,
+				"built with": "golang syscall/js",
+				"more info":  "http://www.gus.io/",
+			},
+		}
+
+		jsonBytes, err := json.MarshalIndent(result, "", "    ")
+		if err != nil {
+			output.Set("textContent", "Error generating JSON")
+			return
+		}
+
+		output.Set("textContent", string(jsonBytes))
+		close(c)
+	}()
+
+	<-c
+}


### PR DESCRIPTION
This PR adds support for running the application on GitHub Pages using WebAssembly.
It introduces a `web/` directory containing the frontend code and a Go Wasm implementation that mimics the original server logic.
A `Makefile` is provided for building the Wasm binary, and a GitHub Actions workflow is added to automate deployment to the `gh-pages` branch.
The Wasm application fetches the user's IP from `api.ipify.org` and displays the JSON output in the browser.

---
*PR created automatically by Jules for task [5642706025353068729](https://jules.google.com/task/5642706025353068729) started by @gustavmaskowitz*